### PR TITLE
feat: Implementa HUD con icone vite e indicatore power-up

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -660,11 +660,20 @@ const Game = {
         ctx.fillStyle = '#fff';
         ctx.fillText(String(this.scores[0]).padStart(6, '0'), 20, 10);
 
-        // Lives P1
-        for (let i = 0; i < this.players[0]?.lives || 0; i++) {
-            ctx.fillStyle = Colors.NICK_BLUE;
-            ctx.fillRect(4 + i * 8, 14, 6, 6);
+        // Vite P1 (icone)
+        const lifeNick = Sprites.get('life_nick');
+        const player1Lives = this.players[0]?.lives || 0;
+        for (let i = 0; i < player1Lives; i++) {
+            if (lifeNick) {
+                ctx.drawImage(lifeNick, 4 + i * 9, 13);
+            } else {
+                ctx.fillStyle = Colors.NICK_BLUE;
+                ctx.fillRect(4 + i * 9, 14, 7, 7);
+            }
         }
+
+        // Power-up attivi P1
+        this.renderPlayerPowerups(ctx, this.players[0], 4, 22);
 
         // Score P2 (se attivo)
         if (this.numPlayers === 2) {
@@ -674,11 +683,20 @@ const Game = {
             ctx.fillStyle = '#fff';
             ctx.fillText(String(this.scores[1]).padStart(6, '0'), CANVAS_WIDTH - 4, 10);
 
-            // Lives P2
-            for (let i = 0; i < this.players[1]?.lives || 0; i++) {
-                ctx.fillStyle = Colors.TOM_GREEN;
-                ctx.fillRect(CANVAS_WIDTH - 10 - i * 8, 14, 6, 6);
+            // Vite P2 (icone)
+            const lifeTom = Sprites.get('life_tom');
+            const player2Lives = this.players[1]?.lives || 0;
+            for (let i = 0; i < player2Lives; i++) {
+                if (lifeTom) {
+                    ctx.drawImage(lifeTom, CANVAS_WIDTH - 11 - i * 9, 13);
+                } else {
+                    ctx.fillStyle = Colors.TOM_GREEN;
+                    ctx.fillRect(CANVAS_WIDTH - 11 - i * 9, 14, 7, 7);
+                }
             }
+
+            // Power-up attivi P2
+            this.renderPlayerPowerups(ctx, this.players[1], CANVAS_WIDTH - 4, 22, true);
         }
 
         // Livello e Timer
@@ -693,6 +711,40 @@ const Game = {
         ctx.fillText('TIME: ' + timeSeconds, CANVAS_WIDTH / 2, 20);
 
         ctx.textAlign = 'left';
+    },
+
+    /**
+     * Renderizza icone power-up attivi per un player
+     */
+    renderPlayerPowerups(ctx, player, x, y, alignRight = false) {
+        if (!player) return;
+
+        const powerupTypes = [
+            { key: 'speed', sprite: 'hud_speed' },
+            { key: 'range', sprite: 'hud_range' },
+            { key: 'fireRate', sprite: 'hud_fire_rate' },
+            { key: 'fly', sprite: 'hud_fly' }
+        ];
+
+        let offsetX = 0;
+        for (const pu of powerupTypes) {
+            if (player.powerups[pu.key]) {
+                const sprite = Sprites.get(pu.sprite);
+                const drawX = alignRight ? x - 6 - offsetX : x + offsetX;
+
+                if (sprite) {
+                    // Lampeggio quando sta per scadere (ultimi 2 secondi)
+                    const timeLeft = player.powerupTimers[pu.key];
+                    const blink = timeLeft <= 2000 && Math.floor(timeLeft / 150) % 2 === 0;
+
+                    if (!blink) {
+                        ctx.drawImage(sprite, drawX, y);
+                    }
+                }
+
+                offsetX += 8;
+            }
+        }
     },
 
     renderHurryUp() {

--- a/js/sprites.js
+++ b/js/sprites.js
@@ -18,6 +18,7 @@ const Sprites = {
         this.generatePumpkinHead();
         this.generateEffects();
         this.generateTitle();
+        this.generateHUD();
 
         Debug.log('All sprites generated');
     },
@@ -670,5 +671,65 @@ const Sprites = {
 
         this.cache['snowflake'] = this.createSprite(8, 8, snowflake, { 1: '#ffffff' });
         this.cache['snowflake_blue'] = this.createSprite(8, 8, snowflake, { 1: '#4a9fff' });
+    },
+
+    // ===========================================
+    // HUD SPRITES
+    // ===========================================
+
+    generateHUD() {
+        // Icona vita Nick (7x7) - faccina pupazzo di neve blu
+        const lifeIconNick = [
+            [0,0,1,1,1,0,0],
+            [0,1,1,1,1,1,0],
+            [1,3,3,1,3,3,1],
+            [1,4,3,1,4,3,1],
+            [1,1,1,5,1,1,1],
+            [0,1,1,1,1,1,0],
+            [0,0,1,1,1,0,0]
+        ];
+
+        // Icona vita Tom (7x7) - faccina pupazzo di neve verde
+        const lifeIconTom = [
+            [0,0,1,1,1,0,0],
+            [0,1,1,1,1,1,0],
+            [1,3,3,1,3,3,1],
+            [1,4,3,1,4,3,1],
+            [1,1,1,5,1,1,1],
+            [0,1,1,1,1,1,0],
+            [0,0,1,1,1,0,0]
+        ];
+
+        const nickPalette = {
+            1: '#4a9fff', // blu
+            3: '#ffffff', // bianco occhi
+            4: '#000000', // pupille
+            5: '#ff9f4a'  // naso arancione
+        };
+
+        const tomPalette = {
+            1: '#4aff4a', // verde
+            3: '#ffffff',
+            4: '#000000',
+            5: '#ff9f4a'
+        };
+
+        this.cache['life_nick'] = this.createSprite(7, 7, lifeIconNick, nickPalette);
+        this.cache['life_tom'] = this.createSprite(7, 7, lifeIconTom, tomPalette);
+
+        // Icone power-up per HUD (6x6) - versione mini
+        const powerupIcon = [
+            [0,0,1,1,0,0],
+            [0,1,2,2,1,0],
+            [0,1,2,2,1,0],
+            [0,1,2,2,1,0],
+            [0,1,2,2,1,0],
+            [0,0,1,1,0,0]
+        ];
+
+        this.cache['hud_speed'] = this.createSprite(6, 6, powerupIcon, { 1: '#8b4513', 2: Colors.POWERUP_RED });
+        this.cache['hud_range'] = this.createSprite(6, 6, powerupIcon, { 1: '#8b4513', 2: Colors.POWERUP_BLUE });
+        this.cache['hud_fire_rate'] = this.createSprite(6, 6, powerupIcon, { 1: '#8b4513', 2: Colors.POWERUP_YELLOW });
+        this.cache['hud_fly'] = this.createSprite(6, 6, powerupIcon, { 1: '#8b4513', 2: Colors.POWERUP_GREEN });
     }
 };


### PR DESCRIPTION
## Summary

- Aggiunge sprite icone vita per Nick (blu) e Tom (verde) in `sprites.js`
- Aggiunge sprite icone power-up per HUD (versione mini 6x6)
- Sostituisce i rettangoli colorati delle vite con icone faccina pupazzo
- Aggiunge indicatore power-up attivi sotto le vite di ogni player
- Implementa lampeggio icone power-up negli ultimi 2 secondi prima della scadenza

Closes #18

## Test plan

- [ ] Avviare il gioco e verificare che le vite siano mostrate come icone pupazzo
- [ ] Verificare icone Nick (blu) a sinistra e Tom (verde) a destra in 2P
- [ ] Raccogliere un power-up e verificare che appaia l'icona corrispondente
- [ ] Attendere che il power-up stia per scadere e verificare il lampeggio
- [ ] Perdere una vita e verificare che l'icona scompaia

🤖 Generated with [Claude Code](https://claude.com/claude-code)